### PR TITLE
Fix CUDA memory issues and improve build robustness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,41 +202,47 @@ add_executable (elaina::soac ALIAS soac)
 target_compile_options(soac PUBLIC ${CMAKE_CXX_FLAGS})
 set_target_properties (soac PROPERTIES OUTPUT_NAME soac)
 
+set(SOA_INCLUDE_GUIDED_DIR "${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided")
+set(SOA_INCLUDE_UNIFORM_DIR "${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform")
+
+file(MAKE_DIRECTORY "${SOA_INCLUDE_GUIDED_DIR}")
+file(MAKE_DIRECTORY "${SOA_INCLUDE_UNIFORM_DIR}")
+
 # workitem
 # 2d
-add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform2d_workitem_soa.h
-    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform2d_workitem.soa > ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform2d_workitem_soa.h
+add_custom_command (OUTPUT ${SOA_INCLUDE_UNIFORM_DIR}/uniform2d_workitem_soa.h
+    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform2d_workitem.soa > ${SOA_INCLUDE_UNIFORM_DIR}/uniform2d_workitem_soa.h
     DEPENDS soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform2d_workitem.soa)
 set (ELAINA_WORKITEM2D_SOA_GENERATED 
-	${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform2d_workitem_soa.h
+	${SOA_INCLUDE_UNIFORM_DIR}/uniform2d_workitem_soa.h
 )
 add_custom_target (elaina_workitem2d_soa_generated DEPENDS ${ELAINA_WORKITEM2D_SOA_GENERATED})
 
 # 3d
-add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform3d_workitem_soa.h
-    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform3d_workitem.soa > ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform3d_workitem_soa.h
+add_custom_command (OUTPUT ${SOA_INCLUDE_UNIFORM_DIR}/uniform3d_workitem_soa.h
+    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform3d_workitem.soa > ${SOA_INCLUDE_UNIFORM_DIR}/uniform3d_workitem_soa.h
     DEPENDS soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/uniform/uniform3d_workitem.soa)
 set (ELAINA_WORKITEM3D_SOA_GENERATED 
-	${CMAKE_CURRENT_BINARY_DIR}/include/integrator/uniform/uniform3d_workitem_soa.h
+	${SOA_INCLUDE_UNIFORM_DIR}/uniform3d_workitem_soa.h
 )
 add_custom_target (elaina_workitem3d_soa_generated DEPENDS ${ELAINA_WORKITEM3D_SOA_GENERATED})
 
 # guideditem
 # 2d
-add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided2d_workitem_soa.h
-    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided2d_workitem.soa > ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided2d_workitem_soa.h
+add_custom_command (OUTPUT ${SOA_INCLUDE_GUIDED_DIR}/guided2d_workitem_soa.h
+    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided2d_workitem.soa > ${SOA_INCLUDE_GUIDED_DIR}/guided2d_workitem_soa.h
     DEPENDS soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided2d_workitem.soa)
 set (ELAINA_GUIDED2D_SOA_GENERATED 
-	${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided2d_workitem_soa.h
+	${SOA_INCLUDE_GUIDED_DIR}/guided2d_workitem_soa.h
 )
 add_custom_target (elaina_guided2d_soa_generated DEPENDS ${ELAINA_GUIDED2D_SOA_GENERATED})
 
 # 3d
-add_custom_command (OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided3d_workitem_soa.h
-    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided3d_workitem.soa > ${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided3d_workitem_soa.h
+add_custom_command (OUTPUT ${SOA_INCLUDE_GUIDED_DIR}/guided3d_workitem_soa.h
+    COMMAND soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided3d_workitem.soa > ${SOA_INCLUDE_GUIDED_DIR}/guided3d_workitem_soa.h
     DEPENDS soac ${CMAKE_CURRENT_SOURCE_DIR}/integrator/guided/guided3d_workitem.soa)
 set (ELAINA_GUIDED3D_SOA_GENERATED 
-	${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided/guided3d_workitem_soa.h
+	${SOA_INCLUDE_GUIDED_DIR}/guided3d_workitem_soa.h
 )
 add_custom_target (elaina_guided3d_soa_generated DEPENDS ${ELAINA_GUIDED3D_SOA_GENERATED})
 

--- a/integrator/guided/integrator.cu
+++ b/integrator/guided/integrator.cu
@@ -1050,6 +1050,7 @@ namespace detail
                 sampleId % integratorSettings.saveSppMetricsDuration == 0 &&
                 sampleId < integratorSettings.saveSppMetricsUntil)
             {
+                CUDA_SYNC_CHECK();
                 renderedImage->reset();
                 ParallelFor(
                     maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
@@ -1064,6 +1065,7 @@ namespace detail
             if (integratorSettings.saveTimeMetricsDuration > 0 &&
                 sampleId % integratorSettings.saveTimeMetricsDuration == 0)
             {
+                CUDA_SYNC_CHECK();
                 renderedImage->reset();
                 ParallelFor(
                     maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
@@ -1080,12 +1082,14 @@ namespace detail
             ELAINA_UPDATE_PROGRESS_BAR(sampleId + 1, integratorSettings.samplesPerPixel);
         }
 
+        CUDA_SYNC_CHECK();
         renderedImage->reset();
         ParallelFor(
             maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
                 Color solution = pixelStateBuffer->solution[pixelId] / float(integratorSettings.samplesPerPixel);
                 renderedImage->put(Color4f(solution, 1.0f), pixelId);
             });
+        CUDA_SYNC_CHECK();
         ELAINA_DESTROY_PROGRESS_BAR();
     }
 

--- a/integrator/uniform/integrator.cu
+++ b/integrator/uniform/integrator.cu
@@ -579,6 +579,7 @@ namespace detail
                 sampleId % integratorSettings.saveSppMetricsDuration == 0 &&
                 sampleId < integratorSettings.saveSppMetricsUntil)
             {
+                CUDA_SYNC_CHECK();
                 renderedImage->reset();
                 ParallelFor(
                     maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
@@ -593,6 +594,7 @@ namespace detail
             if (integratorSettings.saveTimeMetricsDuration > 0 &&
                 sampleId % integratorSettings.saveTimeMetricsDuration == 0)
             {
+                CUDA_SYNC_CHECK();
                 renderedImage->reset();
                 ParallelFor(
                     maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
@@ -609,13 +611,14 @@ namespace detail
             ELAINA_UPDATE_PROGRESS_BAR(sampleId + 1, integratorSettings.samplesPerPixel);
         }
 
+        CUDA_SYNC_CHECK();
         renderedImage->reset();
         ParallelFor(
             maxQueueSize, ELAINA_DEVICE_LAMBDA_GLOBAL(int pixelId) {
                 Color solution = pixelStateBuffer->solution[pixelId] / float(integratorSettings.samplesPerPixel);
                 renderedImage->put(Color4f(solution, 1.0f), pixelId);
             });
-
+        CUDA_SYNC_CHECK();
         ELAINA_DESTROY_PROGRESS_BAR();
     }
 }

--- a/util/film.h
+++ b/util/film.h
@@ -16,139 +16,142 @@ ELAINA_NAMESPACE_BEGIN
 class Film
 {
 public:
-	using SharedPtr = std::shared_ptr<Film>;
-	using Pixel = Color4f;
-	using WeightedPixel = struct
-	{
-		Pixel pixel;
-		float weight;
-	};
+    using SharedPtr = std::shared_ptr<Film>;
+    using Pixel = Color4f;
+    using WeightedPixel = struct
+    {
+        Pixel pixel;
+        float weight;
+    };
 
-	Film() = default;
-	~Film() = default;
-	ELAINA_HOST Film(size_t res_x, size_t res_y)
-	{
-		m_size = {(int)res_x, (int)res_y};
-		m_data.resize(res_x * res_y);
-		reset();
-	}
+    Film() = default;
+    ~Film() = default;
+    ELAINA_HOST Film(size_t res_x, size_t res_y)
+    {
+        m_size = {(int)res_x, (int)res_y};
+        m_data.resize(res_x * res_y);
+        reset();
+    }
 
-	ELAINA_HOST Film(const Vector2f size) : Film(size[0], size[1]) {}
+    ELAINA_HOST Film(const Vector2f size) : Film(size[0], size[1]) {}
 
-	ELAINA_CALLABLE WeightedPixel *data() { return m_data.data(); }
+    ELAINA_CALLABLE WeightedPixel *data() { return m_data.data(); }
 
-	ELAINA_CALLABLE Vector2i size() { return m_size; }
+    ELAINA_CALLABLE Vector2i size() { return m_size; }
 
-	ELAINA_HOST void reset(const Pixel &value = {})
-	{
-		m_data.for_each([value] ELAINA_DEVICE(const WeightedPixel &c) -> WeightedPixel
-						{ return {value, 0}; });
-	}
+    ELAINA_HOST void reset(const Pixel &value = {})
+    {
+        m_data.for_each([value] ELAINA_DEVICE(const WeightedPixel &c) -> WeightedPixel
+                        { return {value, 0}; });
+    }
 
-	ELAINA_HOST void reset(const Pixel &value, const float weight)
-	{
-		m_data.for_each([value, weight] ELAINA_DEVICE(const WeightedPixel &c) -> WeightedPixel
-						{ return {value, weight}; });
-	}
+    ELAINA_HOST void reset(const Pixel &value, const float weight)
+    {
+        m_data.for_each([value, weight] ELAINA_DEVICE(const WeightedPixel &c) -> WeightedPixel
+                        { return {value, weight}; });
+    }
 
-	ELAINA_HOST TypedBuffer<WeightedPixel> &getInternalBuffer() { return m_data; }
+    ELAINA_HOST TypedBuffer<WeightedPixel> &getInternalBuffer() { return m_data; }
 
-	ELAINA_HOST void clear()
-	{
-		m_size = {};
-		m_data.clear();
-	}
+    ELAINA_HOST void clear()
+    {
+        m_size = {};
+        m_data.clear();
+    }
 
-	ELAINA_HOST void resize(const Vector2i &size)
-	{
-		m_size = size;
-		m_data.resize(size[0] * size[1]);
-		reset();
-	}
+    ELAINA_HOST void resize(const Vector2i &size)
+    {
+        m_size = size;
+        m_data.resize(size[0] * size[1]);
+        reset();
+    }
 
-	ELAINA_CALLABLE void put(const Pixel &pixel, const size_t offset)
-	{
-		m_data[offset].pixel += pixel;
-		m_data[offset].weight += 1.f;
-	};
+    ELAINA_CALLABLE void put(const Pixel &pixel, const size_t offset)
+    {
+        m_data[offset].pixel += pixel;
+        m_data[offset].weight += 1.f;
+    };
 
-	ELAINA_CALLABLE void put(const Pixel &pixel, const Vector2i &pos)
-	{
-		size_t idx = pos[0] + pos[1] * m_size[0];
-		put(pixel, idx);
-	}
+    ELAINA_CALLABLE void put(const Pixel &pixel, const Vector2i &pos)
+    {
+        size_t idx = pos[0] + pos[1] * m_size[0];
+        put(pixel, idx);
+    }
 
-	ELAINA_CALLABLE Pixel getPixel(const size_t offset)
-	{
-		const WeightedPixel &pixel = m_data[offset];
-		return pixel.pixel / pixel.weight;
-	}
+    ELAINA_CALLABLE Pixel getPixel(const size_t offset)
+    {
+        const WeightedPixel &pixel = m_data[offset];
+        return pixel.pixel / pixel.weight;
+    }
 
-	ELAINA_CALLABLE Pixel getPixel(const Vector2i &pos)
-	{
-		size_t idx = pos[0] + pos[1] * m_size[0];
-		return getPixel(idx);
-	}
+    ELAINA_CALLABLE Pixel getPixel(const Vector2i &pos)
+    {
+        size_t idx = pos[0] + pos[1] * m_size[0];
+        return getPixel(idx);
+    }
 
 #if defined(__NVCC__)
-	ELAINA_HOST void save(const fs::path &filepath)
-	{
-		size_t n_pixels = m_size[0] * m_size[1];
-		CUDABuffer tmp(n_pixels * sizeof(Pixel));
-		Pixel *pixels_device = reinterpret_cast<Pixel *>(tmp.data());
-		thrust::transform(thrust::device, m_data.data(), m_data.data() + n_pixels, pixels_device,
-						  [] ELAINA_DEVICE(const WeightedPixel &d) -> Pixel
-						  { return d.pixel / d.weight; });
-		Image frame(m_size, Image::Format::RGBAfloat, false);
-		tmp.copy_to_host(frame.data(), n_pixels * sizeof(Color4f));
-		frame.saveImage(filepath);
-	}
+    ELAINA_HOST void save(const fs::path &filepath)
+    {
+        size_t n_pixels = m_size[0] * m_size[1];
+        CUDABuffer tmp(n_pixels * sizeof(Pixel));
+        Pixel *pixels_device = reinterpret_cast<Pixel *>(tmp.data());
+        thrust::transform(thrust::device, m_data.data(), m_data.data() + n_pixels, pixels_device,
+                          [] ELAINA_DEVICE(const WeightedPixel &d) -> Pixel
+                          { return d.pixel / d.weight; });
+        Image frame(m_size, Image::Format::RGBAfloat, false);
+        tmp.copy_to_host(frame.data(), n_pixels * sizeof(Color4f));
+        frame.saveImage(filepath);
+    }
 
-	ELAINA_HOST void saveEnergy(const fs::path &filepath, const ToneMapping tone)
-	{
-		size_t n_pixels = m_size[0] * m_size[1];
-		thrust::device_vector<float> brightness(n_pixels);
-		thrust::transform(m_data.data(), m_data.data() + n_pixels, brightness.begin(), ELAINA_DEVICE_LAMBDA(const WeightedPixel &pixel)->float { return pixel.pixel.matrix().dot(Vector4f(0.299f, 0.587f, 0.114f, 0.0f)); });
-		auto minmax_iterators = thrust::minmax_element(thrust::device, brightness.begin(), brightness.end());
-		float min_val = *(minmax_iterators.first);
-		float max_val = *(minmax_iterators.second);
-		float span = max_val - min_val;
-		if (std::isnan(min_val) || std::isnan(max_val) || span == 0.0f)
-		{
-			ELAINA_LOG(Warning, "Invalid min/max values for tone mapping: min = %f, max = %f", min_val, max_val);
-		}
-		CUDABuffer tmp(n_pixels * sizeof(Pixel));
-		Pixel *pixels_device = reinterpret_cast<Pixel *>(tmp.data());
-		thrust::transform(brightness.begin(), brightness.end(), pixels_device, ELAINA_DEVICE_LAMBDA(const float pixel) {
-							const float normalized_pixel = (pixel - min_val) / span;
-							switch(tone)
-							{
-								default:
-								case ToneMapping::NONE:
-									return Color4f(Color3f(pixel), 1.0f);
-								case ToneMapping::NONE_NORMALIZED:
-									return Color4f(Color3f(normalized_pixel), 1.0f);
-								case ToneMapping::MATLAB_JET:
-									return Color4f(MatlabJet(normalized_pixel), 1.0f);
-								case ToneMapping::MATLAB_PARULA:
-									return Color4f(MatlabParula(normalized_pixel), 1.0f);
-								case ToneMapping::IDL_RDBU:
-									return Color4f(IDLRdBu(normalized_pixel), 1.0f);
-							} });
-		Image frame(m_size, Image::Format::RGBAfloat, false);
-		tmp.copy_to_host(frame.data(), n_pixels * sizeof(Color4f));
-		frame.saveImage(filepath);
-	}
+    ELAINA_HOST void saveEnergy(const fs::path &filepath, const ToneMapping tone)
+    {
+        size_t n_pixels = m_size[0] * m_size[1];
+        thrust::device_vector<float> brightness(n_pixels);
+        thrust::transform(thrust::device, m_data.data(), m_data.data() + n_pixels, brightness.begin(), 
+                        [] ELAINA_DEVICE(const WeightedPixel &pixel) -> float 
+                        { return pixel.pixel.matrix().dot(Vector4f(0.299f, 0.587f, 0.114f, 0.0f)); });
+        auto minmax_iterators = thrust::minmax_element(thrust::device, brightness.begin(), brightness.end());
+        float min_val = *(minmax_iterators.first);
+        float max_val = *(minmax_iterators.second);
+        float span = max_val - min_val;
+        if (std::isnan(min_val) || std::isnan(max_val) || span == 0.0f)
+        {
+            ELAINA_LOG(Warning, "Invalid min/max values for tone mapping: min = %f, max = %f", min_val, max_val);
+        }
+        CUDABuffer tmp(n_pixels * sizeof(Pixel));
+        Pixel *pixels_device = reinterpret_cast<Pixel *>(tmp.data());
+        thrust::transform(thrust::device, brightness.begin(), brightness.end(), pixels_device, 
+                        [min_val, span, tone] ELAINA_DEVICE(const float pixel) -> Pixel {
+                            const float normalized_pixel = (pixel - min_val) / span;
+                            switch(tone)
+                            {
+                                default:
+                                case ToneMapping::NONE:
+                                    return Color4f(Color3f(pixel), 1.0f);
+                                case ToneMapping::NONE_NORMALIZED:
+                                    return Color4f(Color3f(normalized_pixel), 1.0f);
+                                case ToneMapping::MATLAB_JET:
+                                    return Color4f(MatlabJet(normalized_pixel), 1.0f);
+                                case ToneMapping::MATLAB_PARULA:
+                                    return Color4f(MatlabParula(normalized_pixel), 1.0f);
+                                case ToneMapping::IDL_RDBU:
+                                    return Color4f(IDLRdBu(normalized_pixel), 1.0f);
+                            } });
+        Image frame(m_size, Image::Format::RGBAfloat, false);
+        tmp.copy_to_host(frame.data(), n_pixels * sizeof(Color4f));
+        frame.saveImage(filepath);
+    }
 #else
-	ELAINA_HOST void save(const fs::path &filepath)
-	{
-		ELAINA_NOTIMPLEMENTED;
-	}
+    ELAINA_HOST void save(const fs::path &filepath)
+    {
+        ELAINA_NOTIMPLEMENTED;
+    }
 #endif
 
 private:
-	TypedBuffer<WeightedPixel> m_data;
-	Vector2i m_size{};
+    TypedBuffer<WeightedPixel> m_data;
+    Vector2i m_size{};
 };
 
 ELAINA_NAMESPACE_END


### PR DESCRIPTION
### Summary
This PR fixes several bugs and improves build robustness:

1. Added explicit CUDA synchronization before accessing `renderedImage` pointers, preventing illegal memory access observed in CUDA 12.4.
2. Modified the `saveEnergy` function to use `thrust::transform` in the same way as the `save` function, fixing illegal memory access when saving energy.
3. Updated CMake configuration to automatically create the `"${CMAKE_CURRENT_BINARY_DIR}/include/integrator/guided(uniform)"` directory for auto-generated SOA class headers, preventing build errors caused by missing directories.

### Notes
- Tested with CUDA 12.4, no more out-of-bounds errors were observed.
- CMake will now reliably generate the required include directories before code generation.
